### PR TITLE
Notice 및 Account 관련 기능 추가 및 개선

### DIFF
--- a/src/main/kotlin/Rainbow_Frends/Application.kt
+++ b/src/main/kotlin/Rainbow_Frends/Application.kt
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories
 
 @SpringBootApplication
-@EnableJpaRepositories(basePackages = ["Rainbow_Frends.domain.account.repository.jpa", "Rainbow_Frends.domain.User.repository"])
+@EnableJpaRepositories(basePackages = ["Rainbow_Frends.domain.account.repository.jpa", "Rainbow_Frends.domain.User.repository", "Rainbow_Frends.domain.notice.repository"])
 @EnableRedisRepositories(basePackages = ["Rainbow_Frends.domain.account.repository.redis"])
 class SecurityApplication
 

--- a/src/main/kotlin/Rainbow_Frends/domain/User/repository/UserRepository.kt
+++ b/src/main/kotlin/Rainbow_Frends/domain/User/repository/UserRepository.kt
@@ -8,4 +8,5 @@ import java.util.*
 @Repository
 interface UserRepository : JpaRepository<User, UUID> {
     fun findByEmail(email: String): User?
+    //fun findByName(username: String): User?
 }

--- a/src/main/kotlin/Rainbow_Frends/domain/account/entity/Account.kt
+++ b/src/main/kotlin/Rainbow_Frends/domain/account/entity/Account.kt
@@ -5,8 +5,8 @@ import jakarta.persistence.*
 @Entity
 class Account {
     @Id
-    @Column(name = "student_id", unique = true, nullable = false)
-    var student_id: Int? = null
+    @Column(name = "studentId", unique = true, nullable = false)
+    var studentId: Int? = null
 
     @Column(name = "role", nullable = false)
     @Enumerated(EnumType.STRING)

--- a/src/main/kotlin/Rainbow_Frends/domain/account/repository/jpa/AccountRepository.kt
+++ b/src/main/kotlin/Rainbow_Frends/domain/account/repository/jpa/AccountRepository.kt
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
 @Repository
-interface AccountRepository: JpaRepository<Account, Int>
+interface AccountRepository : JpaRepository<Account, Int> {
+    fun findByStudentId(studentId: Int): Account?
+}

--- a/src/main/kotlin/Rainbow_Frends/domain/account/service/impl/SignInServiceImpl.kt
+++ b/src/main/kotlin/Rainbow_Frends/domain/account/service/impl/SignInServiceImpl.kt
@@ -26,7 +26,7 @@ class SignInServiceImpl(
     private val gAuth: GAuth,
     private val refreshRepository: RefreshRepository,
     private val userRepository: UserRepository,
-    private val accountRepository: AccountRepository, // AccountRepository 주입
+    private val accountRepository: AccountRepository,
     private val jwtProvider: JwtProvider
 ) : SignInService {
 
@@ -53,7 +53,7 @@ class SignInServiceImpl(
             val tokenResponse = user.id?.let { jwtProvider.generateTokenDto(it) } ?: throw UserNotFoundException()
 
             saveRefreshToken(tokenResponse, user)
-            saveAccount(user)  // Account 저장 로직 추가
+            saveAccount(user)
 
             return tokenResponse
 
@@ -112,7 +112,7 @@ class SignInServiceImpl(
         val studentId = (studentNum.grade * 1000) + (studentNum.classNum * 100) + studentNum.number
 
         val account = Account().apply {
-            this.student_id = studentId
+            this.studentId = studentId
             this.role = Role.ROLE_AVERAGE_STUDENT
         }
 

--- a/src/main/kotlin/Rainbow_Frends/domain/notice/controller/NoticeController.kt
+++ b/src/main/kotlin/Rainbow_Frends/domain/notice/controller/NoticeController.kt
@@ -1,21 +1,45 @@
 package Rainbow_Frends.domain.notice.controller
 
+import Rainbow_Frends.domain.User.entity.User
+import Rainbow_Frends.domain.account.repository.jpa.AccountRepository
+import Rainbow_Frends.domain.notice.dto.request.NoticeRequest
+import Rainbow_Frends.domain.notice.entity.Notice
+import Rainbow_Frends.domain.notice.service.Impl.NoticeServiceImpl
+import Rainbow_Frends.global.security.jwt.JwtProvider
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.servlet.http.HttpServletRequest
 import org.springframework.http.HttpStatus
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.ResponseStatus
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.security.core.userdetails.UserDetails
+import org.springframework.web.bind.annotation.*
 
 @Tag(name = "공지", description = "공지 관련 API")
 @RestController
-@RequestMapping("/notice")
-class NoticeController {
-    @Operation(summary = "공지 조회 API", description = "공지의 제목,글쓴이,본문,작성시각 조회 API")
-    @ResponseStatus(HttpStatus.OK)
-    @GetMapping
-    fun read(){
+@RequestMapping("/api/notice")
+class NoticeController(
+    private val noticeService: NoticeServiceImpl,
+    private val jwtProvider: JwtProvider,
+    private val accountRepository: AccountRepository
+) {
 
+    @Operation(summary = "공지 조회 API", description = "공지의 제목, 글쓴이, 본문, 작성시각 조회 API")
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping("/all")
+    fun readAll(): List<Notice> {
+        return noticeService.readAllNotice()
+    }
+
+    @Operation(summary = "공지 등록 API", description = "공지를 등록하는 API")
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping
+    fun postNotice(@RequestBody noticeRequest: NoticeRequest, request: HttpServletRequest) {
+        val accessToken = jwtProvider.resolveToken(request)
+        val authentication = jwtProvider.getAuthentication(accessToken!!)
+        val userDetails = authentication.principal as UserDetails
+
+        val user = noticeService.getUserByUsername(userDetails.username) // User 객체를 가져오는 로직
+
+        // 비즈니스 로직은 서비스 레이어에서 처리
+        noticeService.createNotice(noticeRequest, user)
     }
 }

--- a/src/main/kotlin/Rainbow_Frends/domain/notice/controller/NoticeController.kt
+++ b/src/main/kotlin/Rainbow_Frends/domain/notice/controller/NoticeController.kt
@@ -1,6 +1,5 @@
 package Rainbow_Frends.domain.notice.controller
 
-import Rainbow_Frends.domain.User.entity.User
 import Rainbow_Frends.domain.account.repository.jpa.AccountRepository
 import Rainbow_Frends.domain.notice.dto.request.NoticeRequest
 import Rainbow_Frends.domain.notice.entity.Notice
@@ -36,10 +35,7 @@ class NoticeController(
         val accessToken = jwtProvider.resolveToken(request)
         val authentication = jwtProvider.getAuthentication(accessToken!!)
         val userDetails = authentication.principal as UserDetails
-
-        val user = noticeService.getUserByUsername(userDetails.username) // User 객체를 가져오는 로직
-
-        // 비즈니스 로직은 서비스 레이어에서 처리
+        val user = noticeService.getUserByUsername(userDetails.username)
         noticeService.createNotice(noticeRequest, user)
     }
 }

--- a/src/main/kotlin/Rainbow_Frends/domain/notice/dto/request/NoticeRequest.kt
+++ b/src/main/kotlin/Rainbow_Frends/domain/notice/dto/request/NoticeRequest.kt
@@ -1,0 +1,7 @@
+package Rainbow_Frends.domain.notice.dto.request
+
+
+data class NoticeRequest(
+    val title: String,
+    val content: String,
+)

--- a/src/main/kotlin/Rainbow_Frends/domain/notice/entity/Notice.kt
+++ b/src/main/kotlin/Rainbow_Frends/domain/notice/entity/Notice.kt
@@ -1,22 +1,23 @@
 package Rainbow_Frends.domain.notice.entity
 
+import Rainbow_Frends.domain.account.entity.Account
 import jakarta.persistence.*
 import org.hibernate.annotations.CreationTimestamp
 import java.sql.Timestamp
 
 @Entity
-class Notice {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private var notice_id: Long? = null
-    @Column(nullable = false,length = 50)
-    private var title: String? = null
-    @Column(nullable = false)
-    @Lob
-    private var content: String? = null
-    @Column(nullable = false)
-    private var writer: String? = null
-    @Column(nullable = false)
-    @CreationTimestamp
-    private var createDate: Timestamp? = null
-}
+class Notice(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY) var notice_id: Long? = null,
+
+    @Column(nullable = false, length = 50) var title: String,
+
+    @Column(nullable = false) @Lob var content: String,
+
+    @ManyToOne(fetch = FetchType.LAZY) @JoinColumn(
+        name = "writer",
+        referencedColumnName = "studentId",
+        nullable = false
+    ) var writer: Account,
+
+    @Column(nullable = false) @CreationTimestamp var createDate: Timestamp? = null
+)

--- a/src/main/kotlin/Rainbow_Frends/domain/notice/repository/NoticeRepository.kt
+++ b/src/main/kotlin/Rainbow_Frends/domain/notice/repository/NoticeRepository.kt
@@ -1,0 +1,8 @@
+package Rainbow_Frends.domain.notice.repository
+
+import Rainbow_Frends.domain.notice.entity.Notice
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface NoticeRepository : JpaRepository<Notice, Long>

--- a/src/main/kotlin/Rainbow_Frends/domain/notice/service/Impl/NoticeServiceImpl.kt
+++ b/src/main/kotlin/Rainbow_Frends/domain/notice/service/Impl/NoticeServiceImpl.kt
@@ -1,0 +1,50 @@
+package Rainbow_Frends.domain.notice.service.Impl
+
+import Rainbow_Frends.domain.User.entity.User
+import Rainbow_Frends.domain.User.repository.UserRepository
+import Rainbow_Frends.domain.account.repository.jpa.AccountRepository
+import Rainbow_Frends.domain.notice.dto.request.NoticeRequest
+import Rainbow_Frends.domain.notice.entity.Notice
+import Rainbow_Frends.domain.notice.repository.NoticeRepository
+import Rainbow_Frends.domain.notice.service.NoticeService
+import jakarta.transaction.Transactional
+import org.springframework.stereotype.Service
+
+
+@Service
+class NoticeServiceImpl(
+    private val noticeRepository: NoticeRepository,
+    private val accountRepository: AccountRepository,
+    private val userRepository: UserRepository
+) : NoticeService {
+
+    override fun readAllNotice(): List<Notice> {
+        return noticeRepository.findAll()
+    }
+
+    @Transactional
+    fun createNotice(noticeRequest: NoticeRequest, user: User) {
+
+        val studentId = generateStudentId(user)
+
+        val account = accountRepository.findByStudentId(studentId)
+            ?: throw RuntimeException("student_id: $studentId 에 해당하는 Account를 찾을 수 없습니다.")
+
+        val notice = Notice(
+            title = noticeRequest.title,
+            content = noticeRequest.content,
+            writer = account
+        )
+        noticeRepository.save(notice)
+    }
+
+    private fun generateStudentId(user: User): Int {
+        val studentNum = user.studentNum ?: throw IllegalArgumentException("User의 studentNum이 null입니다.")
+        return studentNum.grade * 1000 + studentNum.classNum * 100 + studentNum.number
+    }
+
+    fun getUserByUsername(username: String): User {
+        return userRepository.findByEmail(username)
+            ?: throw RuntimeException("username: $username 에 해당하는 User를 찾을 수 없습니다.")
+    }
+}

--- a/src/main/kotlin/Rainbow_Frends/domain/notice/service/Impl/NoticeServiceImpl.kt
+++ b/src/main/kotlin/Rainbow_Frends/domain/notice/service/Impl/NoticeServiceImpl.kt
@@ -31,9 +31,7 @@ class NoticeServiceImpl(
             ?: throw RuntimeException("student_id: $studentId 에 해당하는 Account를 찾을 수 없습니다.")
 
         val notice = Notice(
-            title = noticeRequest.title,
-            content = noticeRequest.content,
-            writer = account
+            title = noticeRequest.title, content = noticeRequest.content, writer = account
         )
         noticeRepository.save(notice)
     }

--- a/src/main/kotlin/Rainbow_Frends/domain/notice/service/NoticeService.kt
+++ b/src/main/kotlin/Rainbow_Frends/domain/notice/service/NoticeService.kt
@@ -1,0 +1,7 @@
+package Rainbow_Frends.domain.notice.service
+
+import Rainbow_Frends.domain.notice.entity.Notice
+
+interface NoticeService {
+    fun readAllNotice(): List<Notice>
+}

--- a/src/main/kotlin/Rainbow_Frends/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/Rainbow_Frends/global/config/SecurityConfig.kt
@@ -26,9 +26,12 @@ class SecurityConfig(
             .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
             .authorizeHttpRequests { request ->
                 request.requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll().requestMatchers(
-                    "/gauth/authorization", "/api/login/gauth/code", "/api/login/gauth/logout", "/api/login/gauth/reissue"
-                ).permitAll().requestMatchers("/auth/me", "/api/times/remaintime").authenticated()
-                    .requestMatchers("/role/student").hasAuthority("GAUTH_ROLE_STUDENT")
+                    "/gauth/authorization",
+                    "/api/login/gauth/code",
+                    "/api/login/gauth/logout",
+                    "/api/login/gauth/reissue"
+                ).permitAll().requestMatchers("/auth/me", "/api/times/remaintime", "/api/notice", "/api/notice/all")
+                    .authenticated().requestMatchers("/role/student").hasAuthority("GAUTH_ROLE_STUDENT")
                     .requestMatchers("/role/teacher").hasAuthority("GAUTH_ROLE_TEACHER").anyRequest().denyAll()
             }.addFilterBefore(JwtFilter(jwtProvider), UsernamePasswordAuthenticationFilter::class.java)
         gAuthLoginConfigurer.configure(http)

--- a/src/main/kotlin/Rainbow_Frends/global/config/SwaggerConfig.kt
+++ b/src/main/kotlin/Rainbow_Frends/global/config/SwaggerConfig.kt
@@ -11,9 +11,16 @@ class SwaggerConfig {
         return GroupedOpenApi.builder().group("times").pathsToMatch("/api/times/**")
             .packagesToScan("Rainbow_Frends.domain.times.controller").build()
     }
+
     @Bean
     fun gauthApi(): GroupedOpenApi {
         return GroupedOpenApi.builder().group("GAuth").pathsToMatch("/api/login/gauth/**")
             .packagesToScan("Rainbow_Frends.domain.auth.controller").build()
+    }
+
+    @Bean
+    fun noticeApi(): GroupedOpenApi {
+        return GroupedOpenApi.builder().group("Notice").pathsToMatch("/api/notice/**")
+            .packagesToScan("Rainbow_Frends.domain.notice.controller").build()
     }
 }


### PR DESCRIPTION
- 🎨style: Account 엔티티의 필드명 student_id를 studentId로 변경
    - 코드 스타일의 일관성을 유지하기 위해 Account 엔티티의 필드명을 변경했습니다.
- ✨feat: AccountRepository에 findByStudentId 메서드 추가
    - studentId로 Account를 조회할 수 있는 메서드를 추가하여 기능을 확장했습니다.
- ✨feat: JPA 리포지토리 활성화 범위에 notice.repository 추가
    - Notice 엔티티를 관리하기 위해 JPA 리포지토리 활성화 범위에 notice.repository를 추가했습니다.
- ⚙️refactor: Notice 엔티티에 Account 연관 관계 추가 및 생성자 방식 변경
    - Notice 엔티티를 리팩토링하여 Account와의 연관 관계를 설정하고 생성자 방식을 개선했습니다.
- ✨feat: NoticeController에 공지 등록 기능 및 JWT 인증 추가
    - 공지 등록 API를 추가하고 JWT 인증을 통해 보안을 강화했습니다.
- ✨feat: 공지 생성 요청을 위한 NoticeRequest DTO 추가
    - 공지사항 생성 시 필요한 데이터를 전달하기 위한 DTO를 추가했습니다.
- ✨feat: 공지 조회를 위한 NoticeService 인터페이스 추가
    - 모든 공지사항을 조회하는 기능을 제공하기 위해 NoticeService 인터페이스를 추가했습니다.
- ✨feat: NoticeServiceImpl 클래스 추가로 공지 조회 및 생성 기능 구현
    - NoticeServiceImpl 클래스를 추가하여 공지사항의 조회 및 생성 기능을 구현했습니다.
- 🔒security: 공지사항 API 경로에 인증 요구 추가
    - 공지사항 관련 API에 인증 요구를 추가하여 보안을 강화했습니다.
- ✨feat: Swagger 설정에 Notice API 그룹 추가
    - Swagger 설정에 Notice API를 위한 그룹을 추가하여, /api/notice/** 경로에 대한 API 문서를 별도로 관리할 수 있도록 했습니다.
- ✏️chore: UserRepository에 findByName 메서드 추가 (주석 처리)
    - UserRepository에 findByName 메서드를 추가했으나, 현재는 주석 처리되어 사용되지 않습니다.
- ✏️chore: NoticeController 코드 포맷팅 및 주석 제거
    - 코드 가독성을 높이기 위해 NoticeController 클래스의 불필요한 주석과 줄바꿈을 제거했습니다.