### PR TITLE
도메인 설계 변경 및 프로필 사진 관련 취약점 보완

### DIFF
--- a/src/main/kotlin/Rainbow_Frends/domain/account/service/impl/ProfilePictureServiceImpl.kt
+++ b/src/main/kotlin/Rainbow_Frends/domain/account/service/impl/ProfilePictureServiceImpl.kt
@@ -23,7 +23,7 @@ class ProfilePictureServiceImpl(
     private val getStudentId: GetStudentId,
 ) : ProfilePictureService {
 
-    private val allowedImageExtensions = listOf("jpg", "jpeg", "png", "gif")
+    private val allowedImageExtensions = listOf("jpg", "jpeg", "png", "svg")
     override fun updateProfilePicture(request: HttpServletRequest, file: MultipartFile) {
         val studentNum = getStudentId.getStudentId(getUser.getUser(request).username)
         val account = accountRepository.findByStudentId(studentNum)

--- a/src/main/kotlin/Rainbow_Frends/domain/notice/controller/NoticeController.kt
+++ b/src/main/kotlin/Rainbow_Frends/domain/notice/controller/NoticeController.kt
@@ -26,7 +26,7 @@ class NoticeController(
 
     @Operation(summary = "공지 조회 API", description = "공지의 제목, 글쓴이, 본문, 작성시각 조회 API")
     @ResponseStatus(HttpStatus.OK)
-    @GetMapping("/all")
+    @GetMapping
     fun readAll(): List<Notice> {
         return noticeService.readAllNotice()
     }


### PR DESCRIPTION
- ♻️refactor: GET /api/notice/all를 DDD에 맞게 GET /api/notice로 변경 및 프로필 사진의 확장자 제한을 강화